### PR TITLE
PUT http://localhost:3000/api/portfolio/chartでcreatedAtとupdatedAtを許可し…

### DIFF
--- a/back/src/db_operations/portfolio_rader_chart.ts
+++ b/back/src/db_operations/portfolio_rader_chart.ts
@@ -21,7 +21,7 @@ export async function createPortfolioRaderCharts(data: Prisma.portfolio_rader_ch
 
 
 export async function updatePortfolioRaderChartsData(
-    portfolioChartsData: { id: number | null, name: string, pageId: number}[],
+    portfolioChartsData: { id: number | null, name: string, pageId: number }[],
     portfolioRelationsData: { id: number | null, parentId: number, childId: number, depth: number }[],
     portfolioLeavesData: { id: number | null, name: string, score: number, chartIndex: number }[]
 ) {
@@ -56,8 +56,8 @@ export async function updatePortfolioRaderChartsData(
             // 2. リレーションの更新または作成
             const updatedRelations = [];
             for (const relation of portfolioRelationsData) {
-                const parentChartId = updatedCharts[relation.parentId].id ;
-                const childChartId = updatedCharts[relation.childId].id ;
+                const parentChartId = updatedCharts[relation.parentId].id;
+                const childChartId = updatedCharts[relation.childId].id;
 
                 if (relation.id) {
                     const updatedRelation = await prisma.portfolio_rader_chart_relations.update({

--- a/back/src/endpoint/portfolio_rader_chart.ts
+++ b/back/src/endpoint/portfolio_rader_chart.ts
@@ -27,7 +27,9 @@ const updatePortfolioRaderChartsSchema = z.object({
     charts: z.array(
         z.object({
             id: z.number().optional(),
-            name: z.string()
+            name: z.string(),
+            createdAt: z.string().optional(),
+            updatedAt: z.string().optional()
         })
     ),
     relations: z.array(
@@ -35,7 +37,9 @@ const updatePortfolioRaderChartsSchema = z.object({
             id: z.number().optional(),
             parentId: z.number(),
             childId: z.number(),
-            depth: z.number()
+            depth: z.number(),
+            createdAt: z.string().optional(),
+            updatedAt: z.string().optional()
         })
     ),
     leaves: z.array(
@@ -43,7 +47,9 @@ const updatePortfolioRaderChartsSchema = z.object({
             id: z.number().optional(),
             name: z.string(),
             score: z.number(),
-            chartId: z.number()
+            chartId: z.number(),
+            createdAt: z.string().optional(),
+            updatedAt: z.string().optional()
         })
     )
 });
@@ -81,7 +87,7 @@ PortfolioChartApp.put(
                 page_id: portfolioPageData.id,
                 parentId: relation.parentId,
                 childId: relation.childId,
-                depth: relation.depth,
+                depth: relation.depth
             }));
 
             // 3. リーフのデータを整形
@@ -90,7 +96,7 @@ PortfolioChartApp.put(
                 pageId: portfolioPageData.id,
                 name: leave.name,
                 score: leave.score,
-                chartIndex: leave.chartId,
+                chartIndex: leave.chartId
             }));
 
             // 4. トランザクション内でデータを更新


### PR DESCRIPTION
こんな感じでcreatedAtとか含めても大丈夫にした
バック側で捨ててる
charts, relations, leavesも全部同じ挙動
```
PUT http://localhost:3000/api/portfolio/chart
Content-Type: application/json

{
    "userId": 1,
    "charts": [
        {"id": 43, "name": "IT Updated", "createdAt": "dsadsa", "updateAt": "asdad"},
        {"id": 44, "name": "プログラミング Updated", "createdAt": "dsadsa", "updateAt": "asdad"},
        {"id": 45, "name": "ネットワーク Updated", "createdAt": "dsadsa", "updateAt": "asdad"}
    ],
    "relations": [
        {"id": 146, "parentId":0,"childId":0,"depth":0},
        {"id": 147, "parentId":0,"childId":1,"depth":1},
        {"id": 148, "parentId":0,"childId":2,"depth":1},
        {"id": 149, "parentId":1,"childId":1,"depth":1},
        {"id": 150, "parentId":2,"childId":2,"depth":1}
        ],
    "leaves": [
        {"id": 85, "name": "アルゴリズム Updated", "score": 4, "chartId": 1},
        {"id": 86, "name": "基礎文法 Updated", "score": 2, "chartId": 1},
        {"id": 87, "name": "データ構造 Updated", "score": 5, "chartId": 1},
        {"id": 88, "name": "設計 Updated", "score": 4, "chartId": 2},
        {"id": 89, "name": "DNS Updated", "score": 2, "chartId": 2},
        {"id": 90, "name": "DHCP Updated", "score": 3, "chartId": 2}
    ]
}
```